### PR TITLE
fixed forwardRef logic

### DIFF
--- a/src/FlatList.tsx
+++ b/src/FlatList.tsx
@@ -98,7 +98,7 @@ export default (React.forwardRef(
           resetMvcpIfNeeded();
           if (typeof forwardedRef === 'function') {
             forwardedRef(ref);
-          } else if (forwardedRef?.current) {
+          } else if (forwardedRef) {
             forwardedRef.current = ref;
           }
         }}


### PR DESCRIPTION
There is an error regarding checking if forwardRef is in use. The initial state of useRef is `undefined`, because of that `forwardedRef.current` will not be set. Checking if `forwardedRef` (when it's not a function) should be enough.