### PR TITLE
fix: reduced re-renders in JS side and concurrentModification fix in the native side

### DIFF
--- a/android/src/main/java/com/mvcpscrollviewmanager/MvcpScrollViewManagerModule.java
+++ b/android/src/main/java/com/mvcpscrollviewmanager/MvcpScrollViewManagerModule.java
@@ -17,23 +17,16 @@ import com.facebook.react.views.scroll.ReactScrollView;
 import com.facebook.react.views.view.ReactViewGroup;
 
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
-/**
- * Holds the required values for layoutUpdateListener.
- */
-class ScrollViewUIHolders {
-  static int prevFirstVisibleTop = 0;
-  static View firstVisibleView = null;
-  static int currentScrollY = 0;
-}
 
 public class MvcpScrollViewManagerModule extends ReactContextBaseJavaModule {
-  private final ReactApplicationContext reactContext;
-  private HashMap<Integer, UIManagerModuleListener> uiManagerModuleListeners;
+  private HashMap<Integer, UIManagerModuleListener> uiManagerModuleListeners; // rnHandle <-> UIManagerModuleListener
+  private HashMap<Integer, ScrollViewUIHolder> scrollViewUIHolders; // viewTag <-> ScrollViewUIHolder
 
-  MvcpScrollViewManagerModule(ReactApplicationContext reactContext) {
-    super(reactContext);
-    this.reactContext = reactContext;
+  MvcpScrollViewManagerModule(ReactApplicationContext context) {
+    super(context);
   }
 
   @Override
@@ -45,32 +38,57 @@ public class MvcpScrollViewManagerModule extends ReactContextBaseJavaModule {
   public void initialize() {
     super.initialize();
     this.uiManagerModuleListeners = new HashMap<>();
+    this.scrollViewUIHolders = new HashMap<>();
+  }
+
+  private void removeScrollViewUiHolderByRNHandle(int rnHandle) {
+    Iterator<ScrollViewUIHolder> iterator = scrollViewUIHolders.values().iterator();
+    while (iterator.hasNext()) {
+      ScrollViewUIHolder scrollViewUIHolder = iterator.next();
+      if (scrollViewUIHolder.getRnHandle() == rnHandle) {
+        iterator.remove();
+        return;
+      }
+    }
   }
 
   @ReactMethod
   public void enableMaintainVisibleContentPosition(final int viewTag, final int autoscrollToTopThreshold, final int minIndexForVisible, final Promise promise) {
-    final UIManagerModule uiManagerModule = this.reactContext.getNativeModule(UIManagerModule.class);
-    this.reactContext.runOnUiQueueThread(new Runnable() {
+    getReactApplicationContext().runOnUiQueueThread(new Runnable() {
       @Override
       public void run() {
+        final UIManagerModule uiManagerModule = getReactApplicationContext().getNativeModule(UIManagerModule.class);
+        if (uiManagerModule == null) return;
+        ScrollViewUIHolder scrollViewUIHolder = scrollViewUIHolders.get(viewTag);
+        if (scrollViewUIHolder == null) {
+          scrollViewUIHolder = new ScrollViewUIHolder();
+          scrollViewUIHolders.put(viewTag, scrollViewUIHolder);
+        }
         try {
-          final ReactScrollView scrollView = (ReactScrollView)uiManagerModule.resolveView(viewTag);
           final UIManagerModuleListener uiManagerModuleListener = new UIManagerModuleListener() {
             @Override
             public void willDispatchViewUpdates(final UIManagerModule uiManagerModule) {
               uiManagerModule.prependUIBlock(new UIBlock() {
                 @Override
                 public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
-                  ReactViewGroup mContentView = (ReactViewGroup)scrollView.getChildAt(0);
+                  ReactScrollView scrollView = null;
+                  try {
+                    scrollView = (ReactScrollView) uiManagerModule.resolveView(viewTag);
+                  } catch (IllegalViewOperationException ignored) {
+                  }
+                  if (scrollView == null) return;
+                  ScrollViewUIHolder scrollViewUIHolder = scrollViewUIHolders.get(viewTag);
+                  if (scrollViewUIHolder == null) return;
+                  ReactViewGroup mContentView = (ReactViewGroup) scrollView.getChildAt(0);
                   if (mContentView == null) return;
-
-                  ScrollViewUIHolders.currentScrollY = scrollView.getScrollY();
+                  int scrollY = scrollView.getScrollY();
+                  scrollViewUIHolder.setCurrentScrollY(scrollY);
 
                   for (int ii = minIndexForVisible; ii < mContentView.getChildCount(); ++ii) {
                     View subview = mContentView.getChildAt(ii);
-                    if (subview.getTop() >= ScrollViewUIHolders.currentScrollY) {
-                      ScrollViewUIHolders.prevFirstVisibleTop = subview.getTop();
-                      ScrollViewUIHolders.firstVisibleView = subview;
+                    if (subview.getTop() >= scrollY) {
+                      scrollViewUIHolder.setPrevFirstVisibleTop(subview.getTop());
+                      scrollViewUIHolder.setFirstVisibleView(subview);
                       break;
                     }
                   }
@@ -79,32 +97,46 @@ public class MvcpScrollViewManagerModule extends ReactContextBaseJavaModule {
             }
           };
 
+
           UIImplementation.LayoutUpdateListener layoutUpdateListener = new UIImplementation.LayoutUpdateListener() {
             @Override
             public void onLayoutUpdated(ReactShadowNode root) {
-              if (ScrollViewUIHolders.firstVisibleView == null) return;
-
-              int deltaY = ScrollViewUIHolders.firstVisibleView.getTop() - ScrollViewUIHolders.prevFirstVisibleTop;
-
-
-              if (Math.abs(deltaY) > 1) {
-                boolean isWithinThreshold = ScrollViewUIHolders.currentScrollY <= autoscrollToTopThreshold;
-                scrollView.setScrollY(ScrollViewUIHolders.currentScrollY + deltaY);
-
-                // If the offset WAS within the threshold of the start, animate to the start.
-                if (isWithinThreshold) {
-                  scrollView.smoothScrollTo(scrollView.getScrollX(), 0);
+              for (Map.Entry<Integer, ScrollViewUIHolder> entry : scrollViewUIHolders.entrySet()) {
+                ReactScrollView scrollView = null;
+                Integer viewTag = entry.getKey();
+                try {
+                  scrollView = (ReactScrollView) uiManagerModule.resolveView(viewTag);
+                } catch (IllegalViewOperationException ignored) {
+                }
+                if (scrollView == null) {
+                  continue;
+                }
+                ScrollViewUIHolder scrollViewUIHolder = entry.getValue();
+                View firstVisibleView = scrollViewUIHolder.getFirstVisibleView();
+                if (firstVisibleView == null) {
+                  continue;
+                }
+                int deltaY = firstVisibleView.getTop() - scrollViewUIHolder.getPrevFirstVisibleTop();
+                if (Math.abs(deltaY) > 1) {
+                  int currentScrollY = scrollViewUIHolder.getCurrentScrollY();
+                  boolean isWithinThreshold = currentScrollY <= autoscrollToTopThreshold;
+                  scrollView.setScrollY(currentScrollY + deltaY);
+                  // If the offset WAS within the threshold of the start, animate to the start.
+                  if (isWithinThreshold) {
+                    scrollView.smoothScrollTo(scrollView.getScrollX(), 0);
+                  }
                 }
               }
             }
           };
-
-          uiManagerModule.getUIImplementation().setLayoutUpdateListener(layoutUpdateListener);
           uiManagerModule.addUIManagerListener(uiManagerModuleListener);
-          int key = uiManagerModuleListeners.size() + 1;
-          uiManagerModuleListeners.put(key, uiManagerModuleListener);
-          promise.resolve(key);
-        } catch(IllegalViewOperationException e) {
+          uiManagerModule.getUIImplementation().setLayoutUpdateListener(layoutUpdateListener);
+
+          int rnHandle = uiManagerModuleListeners.size() + 1;
+          uiManagerModuleListeners.put(rnHandle, uiManagerModuleListener);
+          scrollViewUIHolder.setRnHandle(rnHandle);
+          promise.resolve(rnHandle);
+        } catch (IllegalViewOperationException e) {
           promise.reject(e);
         }
       }
@@ -112,17 +144,22 @@ public class MvcpScrollViewManagerModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void disableMaintainVisibleContentPosition(int key, Promise promise) {
+  public void disableMaintainVisibleContentPosition(int rnHandle, Promise promise) {
     try {
-      if (key >= 0) {
-        final UIManagerModule uiManagerModule = this.reactContext.getNativeModule(UIManagerModule.class);
+      if (rnHandle >= 0) {
+        final UIManagerModule uiManagerModule = getReactApplicationContext().getNativeModule(UIManagerModule.class);
         if (uiManagerModule != null) {
           // adding to ui block ensures that the underlying callback executes after all view updates are dispatched
           uiManagerModule.addUIBlock(new UIBlock() {
             @Override
             public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
-              uiManagerModule.removeUIManagerListener(uiManagerModuleListeners.remove(key));
-              uiManagerModule.getUIImplementation().removeLayoutUpdateListener();
+              UIManagerModuleListener listener = uiManagerModuleListeners.remove(rnHandle);
+              uiManagerModule.removeUIManagerListener(listener);
+              // when all listeners have been removed, remove the layout listener
+              if (uiManagerModuleListeners.size() == 0) {
+                uiManagerModule.getUIImplementation().removeLayoutUpdateListener();
+              }
+              removeScrollViewUiHolderByRNHandle(rnHandle);
             }
           });
         }

--- a/android/src/main/java/com/mvcpscrollviewmanager/MvcpScrollViewManagerModule.java
+++ b/android/src/main/java/com/mvcpscrollviewmanager/MvcpScrollViewManagerModule.java
@@ -41,6 +41,15 @@ public class MvcpScrollViewManagerModule extends ReactContextBaseJavaModule {
     this.scrollViewUIHolders = new HashMap<>();
   }
 
+  private ScrollViewUIHolder getScrollViewUiHolderByViewTag(int viewTag) {
+    ScrollViewUIHolder scrollViewUIHolder = scrollViewUIHolders.get(viewTag);
+    if (scrollViewUIHolder == null) {
+      scrollViewUIHolder = new ScrollViewUIHolder();
+      scrollViewUIHolders.put(viewTag, scrollViewUIHolder);
+    }
+    return scrollViewUIHolder;
+  }
+
   private void removeScrollViewUiHolderByRNHandle(int rnHandle) {
     Iterator<ScrollViewUIHolder> iterator = scrollViewUIHolders.values().iterator();
     while (iterator.hasNext()) {
@@ -59,11 +68,7 @@ public class MvcpScrollViewManagerModule extends ReactContextBaseJavaModule {
       public void run() {
         final UIManagerModule uiManagerModule = getReactApplicationContext().getNativeModule(UIManagerModule.class);
         if (uiManagerModule == null) return;
-        ScrollViewUIHolder scrollViewUIHolder = scrollViewUIHolders.get(viewTag);
-        if (scrollViewUIHolder == null) {
-          scrollViewUIHolder = new ScrollViewUIHolder();
-          scrollViewUIHolders.put(viewTag, scrollViewUIHolder);
-        }
+        ScrollViewUIHolder scrollViewUIHolder = getScrollViewUiHolderByViewTag(viewTag);
         try {
           final UIManagerModuleListener uiManagerModuleListener = new UIManagerModuleListener() {
             @Override
@@ -77,8 +82,6 @@ public class MvcpScrollViewManagerModule extends ReactContextBaseJavaModule {
                   } catch (IllegalViewOperationException ignored) {
                   }
                   if (scrollView == null) return;
-                  ScrollViewUIHolder scrollViewUIHolder = scrollViewUIHolders.get(viewTag);
-                  if (scrollViewUIHolder == null) return;
                   ReactViewGroup mContentView = (ReactViewGroup) scrollView.getChildAt(0);
                   if (mContentView == null) return;
                   int scrollY = scrollView.getScrollY();

--- a/android/src/main/java/com/mvcpscrollviewmanager/MvcpScrollViewManagerModule.java
+++ b/android/src/main/java/com/mvcpscrollviewmanager/MvcpScrollViewManagerModule.java
@@ -116,8 +116,16 @@ public class MvcpScrollViewManagerModule extends ReactContextBaseJavaModule {
     try {
       if (key >= 0) {
         final UIManagerModule uiManagerModule = this.reactContext.getNativeModule(UIManagerModule.class);
-        uiManagerModule.removeUIManagerListener(uiManagerModuleListeners.remove(key));
-        uiManagerModule.getUIImplementation().removeLayoutUpdateListener();
+        if (uiManagerModule != null) {
+          // adding to ui block ensures that the underlying callback executes after all view updates are dispatched
+          uiManagerModule.addUIBlock(new UIBlock() {
+            @Override
+            public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+              uiManagerModule.removeUIManagerListener(uiManagerModuleListeners.remove(key));
+              uiManagerModule.getUIImplementation().removeLayoutUpdateListener();
+            }
+          });
+        }
       }
       promise.resolve(null);
     } catch (Exception e) {

--- a/android/src/main/java/com/mvcpscrollviewmanager/ScrollViewUIHolder.java
+++ b/android/src/main/java/com/mvcpscrollviewmanager/ScrollViewUIHolder.java
@@ -1,0 +1,43 @@
+package com.mvcpscrollviewmanager;
+
+import android.view.View;
+
+public class ScrollViewUIHolder {
+  private int prevFirstVisibleTop = 0;
+  private View firstVisibleView;
+  private int currentScrollY = 0;
+  private int rnHandle = 0;
+
+  public int getRnHandle() {
+    return rnHandle;
+  }
+
+  public void setRnHandle(int rnHandle) {
+    this.rnHandle = rnHandle;
+  }
+
+  public int getPrevFirstVisibleTop() {
+    return prevFirstVisibleTop;
+  }
+
+  public void setPrevFirstVisibleTop(int prevFirstVisibleTop) {
+    this.prevFirstVisibleTop = prevFirstVisibleTop;
+  }
+
+  public View getFirstVisibleView() {
+    return firstVisibleView;
+  }
+
+  public void setFirstVisibleView(View firstVisibleView) {
+    this.firstVisibleView = firstVisibleView;
+  }
+
+  public int getCurrentScrollY() {
+    return currentScrollY;
+  }
+
+  public void setCurrentScrollY(int currentScrollY) {
+    this.currentScrollY = currentScrollY;
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -140,8 +140,5 @@
       "module",
       "typescript"
     ]
-  },
-  "dependencies": {
-    "lodash.debounce": "^4.0.8"
   }
 }

--- a/src/FlatList.android.tsx
+++ b/src/FlatList.android.tsx
@@ -89,7 +89,7 @@ export default (React.forwardRef(
       const hasMvcpChanged =
         autoscrollToTopThreshold.current !== propAutoscrollToTopThreshold ||
         minIndexForVisible.current !== propMinIndexForVisible ||
-        (isMvcpPropPresentRef.current && !props.maintainVisibleContentPosition);
+        isMvcpPropPresentRef.current !== !!props.maintainVisibleContentPosition;
 
       if (hasMvcpChanged) {
         enableMvcpRetriesCount.current = 0;

--- a/src/FlatList.android.tsx
+++ b/src/FlatList.android.tsx
@@ -38,10 +38,13 @@ export default (React.forwardRef(
     const enableMvcpWithRetriesRef = useRef(() => {
       // debounce to wait till consecutive mvcp enabling
       // this ensures that always previous handles are disabled first
+      if (debounceTimeoutId.current) {
+        clearTimeout(debounceTimeoutId.current);
+      }
       debounceTimeoutId.current = setTimeout(async () => {
-        if (debounceTimeoutId.current) {
-          clearTimeout(debounceTimeoutId.current);
-        }
+        // disable any previous enabled handles
+        await disableMvcpRef.current();
+
         if (
           !flRef.current ||
           !isMvcpPropPresentRef.current ||
@@ -51,9 +54,6 @@ export default (React.forwardRef(
           return;
         }
         const scrollableNode = flRef.current.getScrollableNode();
-
-        // disable any previous enabled handles
-        await disableMvcpRef.current();
 
         try {
           const _handle: number = await ScrollViewManager.enableMaintainVisibleContentPosition(

--- a/src/FlatList.android.tsx
+++ b/src/FlatList.android.tsx
@@ -11,97 +11,118 @@ export default (React.forwardRef(
       | MutableRefObject<FlatList<T> | null>
       | null
   ) => {
-    const { maintainVisibleContentPosition: mvcp } = props;
-
     const flRef = useRef<FlatList<T> | null>(null);
-    const isMvcpEnabled = useRef<any>(null);
-    const autoscrollToTopThreshold = useRef<number | null>();
-    const minIndexForVisible = useRef<number>();
-    const handle = useRef<any>(null);
-    const enableMvcpRetries = useRef<number>(0);
+    const isMvcpEnabledNative = useRef<boolean>(false);
+    const handle = useRef<number | null>(null);
+    const enableMvcpRetriesCount = useRef<number>(0);
+    const isMvcpPropPresentRef = useRef(!!props.maintainVisibleContentPosition);
 
-    const propAutoscrollToTopThreshold =
-      mvcp?.autoscrollToTopThreshold || -Number.MAX_SAFE_INTEGER;
-    const propMinIndexForVisible = mvcp?.minIndexForVisible || 1;
-    const hasMvcpChanged =
-      autoscrollToTopThreshold.current !== propAutoscrollToTopThreshold ||
-      minIndexForVisible.current !== propMinIndexForVisible;
-    const enableMvcp = () => {
-      if (!flRef.current) return;
-
-      const scrollableNode = flRef.current.getScrollableNode();
-      const enableMvcpPromise = ScrollViewManager.enableMaintainVisibleContentPosition(
-        scrollableNode,
-        autoscrollToTopThreshold.current,
-        minIndexForVisible.current
-      );
-
-      return enableMvcpPromise.then((_handle: number) => {
-        handle.current = _handle;
-        enableMvcpRetries.current = 0;
-      });
-    };
-
-    const enableMvcpWithRetries = () => {
-      return enableMvcp()?.catch(() => {
-        /**
-         * enableMaintainVisibleContentPosition from native module may throw IllegalViewOperationException,
-         * in case view is not ready yet. In that case, lets do a retry!!
-         */
-        if (enableMvcpRetries.current < 10) {
-          setTimeout(enableMvcpWithRetries, 10);
-          enableMvcpRetries.current += 1;
-        }
-      });
-    };
-
-    const disableMvcp: () => Promise<void> = () => {
-      if (!ScrollViewManager || !handle?.current) {
-        return Promise.resolve();
+    const autoscrollToTopThreshold = useRef<number | null>(
+      props.maintainVisibleContentPosition?.autoscrollToTopThreshold ||
+        -Number.MAX_SAFE_INTEGER
+    );
+    const minIndexForVisible = useRef<number>(
+      props.maintainVisibleContentPosition?.minIndexForVisible || 1
+    );
+    const retryTimeoutId = useRef<NodeJS.Timeout>();
+    const debounceTimeoutId = useRef<NodeJS.Timeout>();
+    const disableMvcpRef = useRef(async () => {
+      isMvcpEnabledNative.current = false;
+      if (!handle?.current) {
+        return;
       }
-
-      return ScrollViewManager.disableMaintainVisibleContentPosition(
+      await ScrollViewManager.disableMaintainVisibleContentPosition(
         handle.current
       );
-    };
+    });
+    const enableMvcpWithRetriesRef = useRef(() => {
+      // debounce to wait till consecutive mvcp enabling
+      // this ensures that always previous handles are disabled first
+      debounceTimeoutId.current = setTimeout(async () => {
+        if (debounceTimeoutId.current) {
+          clearTimeout(debounceTimeoutId.current);
+        }
+        if (
+          !flRef.current ||
+          !isMvcpPropPresentRef.current ||
+          isMvcpEnabledNative.current ||
+          Platform.OS !== 'android'
+        ) {
+          return;
+        }
+        const scrollableNode = flRef.current.getScrollableNode();
 
-    // We can only call enableMaintainVisibleContentPosition once the ref to underlying scrollview is ready.
-    const resetMvcpIfNeeded = (): void => {
-      if (!mvcp || Platform.OS !== 'android' || !flRef.current) {
-        return;
-      }
+        // disable any previous enabled handles
+        await disableMvcpRef.current();
 
-      /**
-       * If the enableMaintainVisibleContentPosition has already been called, then
-       * lets not call it again, unless prop values of mvcp changed.
-       *
-       * This condition is important since `resetMvcpIfNeeded` gets called in refCallback,
-       * which gets called by react on every update to list.
-       */
-      if (isMvcpEnabled.current && !hasMvcpChanged) {
-        return;
-      }
-      autoscrollToTopThreshold.current = propAutoscrollToTopThreshold;
-      minIndexForVisible.current = propMinIndexForVisible;
-
-      isMvcpEnabled.current = true;
-      disableMvcp().then(enableMvcpWithRetries);
-    };
-
-    const refCallback: (instance: FlatList<T> | null) => void = (ref) => {
-      flRef.current = ref;
-
-      resetMvcpIfNeeded();
-      if (typeof forwardedRef === 'function') {
-        forwardedRef(ref);
-      } else if (forwardedRef) {
-        forwardedRef.current = ref;
-      }
-    };
+        try {
+          const _handle: number = await ScrollViewManager.enableMaintainVisibleContentPosition(
+            scrollableNode,
+            autoscrollToTopThreshold.current,
+            minIndexForVisible.current
+          );
+          handle.current = _handle;
+        } catch (error: any) {
+          /**
+           * enableMaintainVisibleContentPosition from native module may throw IllegalViewOperationException,
+           * in case view is not ready yet. In that case, lets do a retry!! (max of 10 tries)
+           */
+          if (enableMvcpRetriesCount.current < 10) {
+            retryTimeoutId.current = setTimeout(
+              enableMvcpWithRetriesRef.current,
+              100
+            );
+            enableMvcpRetriesCount.current += 1;
+          }
+        }
+      }, 300);
+    });
 
     useEffect(() => {
-      // disable before unmounting
+      // when the mvcp prop changes
+      // enable natively again, if the prop has changed
+      const propAutoscrollToTopThreshold =
+        props.maintainVisibleContentPosition?.autoscrollToTopThreshold ||
+        -Number.MAX_SAFE_INTEGER;
+      const propMinIndexForVisible =
+        props.maintainVisibleContentPosition?.minIndexForVisible || 1;
+      const hasMvcpChanged =
+        autoscrollToTopThreshold.current !== propAutoscrollToTopThreshold ||
+        minIndexForVisible.current !== propMinIndexForVisible ||
+        (isMvcpPropPresentRef.current && !props.maintainVisibleContentPosition);
+
+      if (hasMvcpChanged) {
+        enableMvcpRetriesCount.current = 0;
+        autoscrollToTopThreshold.current = propAutoscrollToTopThreshold;
+        minIndexForVisible.current = propMinIndexForVisible;
+        isMvcpPropPresentRef.current = !!props.maintainVisibleContentPosition;
+        enableMvcpWithRetriesRef.current();
+      }
+    }, [props.maintainVisibleContentPosition]);
+
+    const refCallback = useRef<(instance: FlatList<T> | null) => void>(
+      (ref) => {
+        flRef.current = ref;
+        enableMvcpWithRetriesRef.current();
+        if (typeof forwardedRef === 'function') {
+          forwardedRef(ref);
+        } else if (forwardedRef) {
+          forwardedRef.current = ref;
+        }
+      }
+    ).current;
+
+    useEffect(() => {
+      const disableMvcp = disableMvcpRef.current;
       return () => {
+        // clean up the retry mechanism
+        if (debounceTimeoutId.current) {
+          clearTimeout(debounceTimeoutId.current);
+        }
+        // clean up any debounce
+        if (debounceTimeoutId.current) {
+          clearTimeout(debounceTimeoutId.current);
+        }
         disableMvcp();
       };
     }, []);

--- a/src/ScrollView.android.tsx
+++ b/src/ScrollView.android.tsx
@@ -43,10 +43,13 @@ export default React.forwardRef(
     const enableMvcpWithRetriesRef = useRef(() => {
       // debounce to wait till consecutive mvcp enabling
       // this ensures that always previous handles are disabled first
+      if (debounceTimeoutId.current) {
+        clearTimeout(debounceTimeoutId.current);
+      }
       debounceTimeoutId.current = setTimeout(async () => {
-        if (debounceTimeoutId.current) {
-          clearTimeout(debounceTimeoutId.current);
-        }
+        // disable any previous enabled handles
+        await disableMvcpRef.current();
+
         if (
           !flRef.current ||
           !isMvcpPropPresentRef.current ||
@@ -56,9 +59,6 @@ export default React.forwardRef(
           return;
         }
         const scrollableNode = flRef.current.getScrollableNode();
-
-        // disable any previous enabled handles
-        await disableMvcpRef.current();
 
         try {
           const _handle: number = await ScrollViewManager.enableMaintainVisibleContentPosition(

--- a/src/ScrollView.android.tsx
+++ b/src/ScrollView.android.tsx
@@ -94,7 +94,7 @@ export default React.forwardRef(
       const hasMvcpChanged =
         autoscrollToTopThreshold.current !== propAutoscrollToTopThreshold ||
         minIndexForVisible.current !== propMinIndexForVisible ||
-        (isMvcpPropPresentRef.current && !props.maintainVisibleContentPosition);
+        isMvcpPropPresentRef.current !== !!props.maintainVisibleContentPosition;
 
       if (hasMvcpChanged) {
         enableMvcpRetriesCount.current = 0;

--- a/src/ScrollView.android.tsx
+++ b/src/ScrollView.android.tsx
@@ -16,100 +16,116 @@ export default React.forwardRef(
       | MutableRefObject<ScrollView | null>
       | null
   ) => {
-    const { maintainVisibleContentPosition: mvcp } = props;
-
     const flRef = useRef<ScrollView | null>(null);
-    const isMvcpEnabled = useRef<any>(null);
-    const autoscrollToTopThreshold = useRef<number | null>();
-    const minIndexForVisible = useRef<number>();
-    const handle = useRef<any>(null);
-    const enableMvcpRetries = useRef<number>(0);
+    const isMvcpEnabledNative = useRef<boolean>(false);
+    const handle = useRef<number | null>(null);
+    const enableMvcpRetriesCount = useRef<number>(0);
+    const isMvcpPropPresentRef = useRef(!!props.maintainVisibleContentPosition);
 
-    const propAutoscrollToTopThreshold =
-      mvcp?.autoscrollToTopThreshold || -Number.MAX_SAFE_INTEGER;
-    const propMinIndexForVisible = mvcp?.minIndexForVisible || 1;
-
-    const hasMvcpChanged =
-      autoscrollToTopThreshold.current !== propAutoscrollToTopThreshold ||
-      minIndexForVisible.current !== propMinIndexForVisible;
-
-    const enableMvcp = () => {
-      if (!flRef.current) return;
-
-      const scrollableNode = flRef.current.getScrollableNode();
-      const enableMvcpPromise = ScrollViewManager.enableMaintainVisibleContentPosition(
-        scrollableNode,
-        autoscrollToTopThreshold.current,
-        minIndexForVisible.current
-      );
-
-      return enableMvcpPromise.then((_handle: number) => {
-        handle.current = _handle;
-        enableMvcpRetries.current = 0;
-      });
-    };
-
-    const enableMvcpWithRetries = () => {
-      autoscrollToTopThreshold.current = propAutoscrollToTopThreshold;
-      minIndexForVisible.current = propMinIndexForVisible;
-
-      return enableMvcp()?.catch(() => {
-        /**
-         * enableMaintainVisibleContentPosition from native module may throw IllegalViewOperationException,
-         * in case view is not ready yet. In that case, lets do a retry!!
-         */
-        if (enableMvcpRetries.current < 10) {
-          setTimeout(enableMvcp, 10);
-          enableMvcpRetries.current += 1;
-        }
-      });
-    };
-
-    const disableMvcp: () => Promise<void> = () => {
-      if (!ScrollViewManager || !handle?.current) {
-        return Promise.resolve();
+    const autoscrollToTopThreshold = useRef<number | null>(
+      props.maintainVisibleContentPosition?.autoscrollToTopThreshold ||
+        -Number.MAX_SAFE_INTEGER
+    );
+    const minIndexForVisible = useRef<number>(
+      props.maintainVisibleContentPosition?.minIndexForVisible || 1
+    );
+    const retryTimeoutId = useRef<NodeJS.Timeout>();
+    const debounceTimeoutId = useRef<NodeJS.Timeout>();
+    const disableMvcpRef = useRef(async () => {
+      isMvcpEnabledNative.current = false;
+      if (!handle?.current) {
+        return;
       }
-
-      return ScrollViewManager.disableMaintainVisibleContentPosition(
+      await ScrollViewManager.disableMaintainVisibleContentPosition(
         handle.current
       );
-    };
+    });
+    const enableMvcpWithRetriesRef = useRef(() => {
+      // debounce to wait till consecutive mvcp enabling
+      // this ensures that always previous handles are disabled first
+      debounceTimeoutId.current = setTimeout(async () => {
+        if (debounceTimeoutId.current) {
+          clearTimeout(debounceTimeoutId.current);
+        }
+        if (
+          !flRef.current ||
+          !isMvcpPropPresentRef.current ||
+          isMvcpEnabledNative.current ||
+          Platform.OS !== 'android'
+        ) {
+          return;
+        }
+        const scrollableNode = flRef.current.getScrollableNode();
 
-    // We can only call enableMaintainVisibleContentPosition once the ref to underlying scrollview is ready.
-    const resetMvcpIfNeeded = (): void => {
-      if (!mvcp || Platform.OS !== 'android' || !flRef.current) {
-        return;
+        // disable any previous enabled handles
+        await disableMvcpRef.current();
+
+        try {
+          const _handle: number = await ScrollViewManager.enableMaintainVisibleContentPosition(
+            scrollableNode,
+            autoscrollToTopThreshold.current,
+            minIndexForVisible.current
+          );
+          handle.current = _handle;
+        } catch (error: any) {
+          /**
+           * enableMaintainVisibleContentPosition from native module may throw IllegalViewOperationException,
+           * in case view is not ready yet. In that case, lets do a retry!! (max of 10 tries)
+           */
+          if (enableMvcpRetriesCount.current < 10) {
+            retryTimeoutId.current = setTimeout(
+              enableMvcpWithRetriesRef.current,
+              100
+            );
+            enableMvcpRetriesCount.current += 1;
+          }
+        }
+      }, 300);
+    });
+
+    useEffect(() => {
+      // when the mvcp prop changes
+      // enable natively again, if the prop has changed
+      const propAutoscrollToTopThreshold =
+        props.maintainVisibleContentPosition?.autoscrollToTopThreshold ||
+        -Number.MAX_SAFE_INTEGER;
+      const propMinIndexForVisible =
+        props.maintainVisibleContentPosition?.minIndexForVisible || 1;
+      const hasMvcpChanged =
+        autoscrollToTopThreshold.current !== propAutoscrollToTopThreshold ||
+        minIndexForVisible.current !== propMinIndexForVisible ||
+        (isMvcpPropPresentRef.current && !props.maintainVisibleContentPosition);
+
+      if (hasMvcpChanged) {
+        enableMvcpRetriesCount.current = 0;
+        autoscrollToTopThreshold.current = propAutoscrollToTopThreshold;
+        minIndexForVisible.current = propMinIndexForVisible;
+        isMvcpPropPresentRef.current = !!props.maintainVisibleContentPosition;
+        enableMvcpWithRetriesRef.current();
       }
+    }, [props.maintainVisibleContentPosition]);
 
-      /**
-       * If the enableMaintainVisibleContentPosition has already been called, then
-       * lets not call it again, unless prop values of mvcp changed.
-       *
-       * This condition is important since `resetMvcpIfNeeded` gets called in refCallback,
-       * which gets called by react on every update to list.
-       */
-      if (isMvcpEnabled.current && !hasMvcpChanged) {
-        return;
-      }
-
-      isMvcpEnabled.current = true;
-      disableMvcp().then(enableMvcpWithRetries);
-    };
-
-    const refCallback: (instance: ScrollView | null) => void = (ref) => {
+    const refCallback = useRef<(instance: ScrollView | null) => void>((ref) => {
       flRef.current = ref;
-
-      resetMvcpIfNeeded();
+      enableMvcpWithRetriesRef.current();
       if (typeof forwardedRef === 'function') {
         forwardedRef(ref);
       } else if (forwardedRef) {
         forwardedRef.current = ref;
       }
-    };
+    }).current;
 
     useEffect(() => {
-      // disable before unmounting
+      const disableMvcp = disableMvcpRef.current;
       return () => {
+        // clean up the retry mechanism
+        if (debounceTimeoutId.current) {
+          clearTimeout(debounceTimeoutId.current);
+        }
+        // clean up any debounce
+        if (debounceTimeoutId.current) {
+          clearTimeout(debounceTimeoutId.current);
+        }
         disableMvcp();
       };
     }, []);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,8 @@
     "esModuleInterop": true,
     "importsNotUsedAsValues": "error",
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-native",
-    "lib": ["esnext", "DOM"],
+    "jsx": "react",
+    "lib": ["esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
@@ -19,16 +19,10 @@
     "noStrictGenericChecks": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext",
-    "allowSyntheticDefaultImports": true,
-    "noEmitOnError": false,
-    "noImplicitAny": true,
-    "allowJs": true,
-    "checkJs": false
+    "target": "esnext"
   },
   "exclude": ["./Example/"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6390,11 +6390,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.debounce@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
-
 lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"


### PR DESCRIPTION
## JS

* reduce needless reenders, achieved mainly by making refCallback function in useRef
* fix tsconfig overwrite warn error, also aligned the tsconfig to the one provided by builder-bob by default
* removed lodash dependency as it was unused
* added debounce, as fast consecutive enabling of mvcp makes disabling called with a null handle while enabling is ongoing.

## Android native

* fixes #30 by ensuring that removal happens in UI thread as well, meaning no "concurrent" modification of the uiModuleListeners arrayList held by RN core
  - Verified using the [Stream SlackClone Sample App](https://github.com/GetStream/react-native-samples/tree/main/projects/SlackClone)

* fixes #16  by having multiple scrollViewUI holders, based on the PR #21

* remove static reference to firstVisibleView, thereby fixing a definite memory leak.